### PR TITLE
feat: add panoptic v1.1 tvl

### DIFF
--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -51,7 +51,7 @@ async function tvl(api) {
 
   const poolData = {}
   const ownerTokens = []
-  uniPools.forEach((pool, i) => {
+  univ3Pools.forEach((pool, i) => {
     // to compute tokens locked in panoptic pools
     ownerTokens.push([[v3token0s[i], v3token1s[i]], v1PoolDeployedLogs[i].poolAddress])
 

--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -39,7 +39,7 @@ const config = {
 
 async function tvl(api) {
   const chain = api.chain
-  const { v1StartBlock, graphUrl, safeBlockLimit } = config[chain]
+  const { v1StartBlock, v1point1StartBlock, graphUrl, safeBlockLimit } = config[chain]
 
   const v1PoolDeployedLogs = await getLogs2({ api, target: V1_FACTORY, fromBlock: v1StartBlock, eventAbi: abi.PoolDeployed, })
   const v1point1PoolDeployedLogs = await getLogs2({ api, target: V1_POINT_1_FACTORY, fromBlock: v1point1StartBlock, eventAbi: abi.PoolDeployed, })

--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -6,7 +6,7 @@ const V1_FACTORY = '0x000000000000010a1DEc6c46371A28A071F8bb01'
 const V1_POINT_1_FACTORY = '0x0000000000000CF008e9bf9D01f8306029724c80'
 const V1_SFPM = '0x0000000000000DEdEDdD16227aA3D836C5753194'
 const V1_POINT_1_SFPM = '0x0000000000000aAbbcfCA8100a9ee78124E97B33'
-
+const V4_POOL_MANAGER = '0x000000000004444c5dc75cB358380D2e3dE08A90'
 
 const SFPMChunksQuery = `
 query SFPMChunks($lastId: ID, $block: Int) {
@@ -42,25 +42,30 @@ async function tvl(api) {
   const { v1StartBlock, v1point1StartBlock, graphUrl, safeBlockLimit } = config[chain]
 
   const v1PoolDeployedLogs = await getLogs2({ api, target: V1_FACTORY, fromBlock: v1StartBlock, eventAbi: abi.PoolDeployed, })
-  const v1point1PoolDeployedLogs = await getLogs2({ api, target: V1_POINT_1_FACTORY, fromBlock: v1point1StartBlock, eventAbi: abi.PoolDeployed, })
-  const uniPools = poolDeployedLogs.map(log => log.uniswapPool.toLowerCase())
-  const token0s = await api.multiCall({ abi: 'address:token0', calls: uniPools })
-  const token1s = await api.multiCall({ abi: 'address:token1', calls: uniPools })
-  const slot0s = await api.multiCall({ abi: 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)', calls: uniPools })
+
+  const univ3Pools = v1PoolDeployedLogs.map(log => log.uniswapPool.toLowerCase())
+
+  const v3token0s = await api.multiCall({ abi: 'address:token0', calls: univ3Pools })
+  const v3token1s = await api.multiCall({ abi: 'address:token1', calls: univ3Pools })
+  const v3slot0s = await api.multiCall({ abi: 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)', calls: univ3Pools })
 
   const poolData = {}
   const ownerTokens = []
   uniPools.forEach((pool, i) => {
     // to compute tokens locked in panoptic pools
-    ownerTokens.push([[token0s[i], token1s[i]], poolDeployedLogs[i].poolAddress])
+    ownerTokens.push([[v3token0s[i], v3token1s[i]], v1PoolDeployedLogs[i].poolAddress])
 
     // to compute value locked in uni v3 pools
     poolData[pool] = {
-      token0: token0s[i],
-      token1: token1s[i],
-      tick: slot0s[i].tick,
+      token0: v3token0s[i],
+      token1: v3token1s[i],
+      tick: v3slot0s[i].tick,
     }
   })
+
+  const v1point1PoolDeployedLogs = await getLogs2({ api, target: V1_POINT_1_FACTORY, fromBlock: v1point1StartBlock, eventAbi: abi.PoolDeployed, })
+  const univ4Pools = v1point1PoolDeployedLogs.map(log => log.uniswapPool.toLowerCase())
+  // TODO: get the token0, token1 and slot0 for each univ4pool and then also push those onto ownerTokens and poolData
 
   await api.sumTokens({ ownerTokens })
 

--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -2,13 +2,15 @@ const { getLogs2 } = require('../helper/cache/getLogs')
 const { cachedGraphQuery } = require("../helper/cache");
 const { addUniV3LikePosition } = require('../helper/unwrapLPs');
 
-const FACTORY = '0x000000000000010a1DEc6c46371A28A071F8bb01'
-const SFPM = '0x0000000000000DEdEDdD16227aA3D836C5753194'
+const V1_FACTORY = '0x000000000000010a1DEc6c46371A28A071F8bb01'
+const V1_POINT_1_FACTORY = '0x0000000000000CF008e9bf9D01f8306029724c80'
+const V1_SFPM = '0x0000000000000DEdEDdD16227aA3D836C5753194'
+const V1_POINT_1_SFPM = '0x0000000000000aAbbcfCA8100a9ee78124E97B33'
 
 
 const SFPMChunksQuery = `
 query SFPMChunks($lastId: ID, $block: Int) {
-  chunks(first: 1000 
+  chunks(first: 1000
     block: {number: $block}
     where: {and: [{id_gt: $lastId}, { netLiquidity_gt: 100}]}
     ) {
@@ -27,18 +29,20 @@ const abi = {
 
 const config = {
   ethereum: {
-    graphUrl: 'https://api.goldsky.com/api/public/project_cl9gc21q105380hxuh8ks53k3/subgraphs/panoptic-subgraph-mainnet/1.0.2/gn',
-    startBlock: 21389983,
+    graphUrl: 'https://api.goldsky.com/api/public/project_cl9gc21q105380hxuh8ks53k3/subgraphs/panoptic-subgraph-mainnet/prod/gn',
+    v1StartBlock: 21389983,
+    v1point1StartBlock: 21745190,
     safeBlockLimit: 50
   }
 }
 
 
-async function tvl(api) {
+async function tvlV1(api) {
   const chain = api.chain
-  const { startBlock, graphUrl, safeBlockLimit } = config[chain]
+  const { v1StartBlock, graphUrl, safeBlockLimit } = config[chain]
 
-  const poolDeployedLogs = await getLogs2({ api, target: FACTORY, fromBlock: startBlock, eventAbi: abi.PoolDeployed, })
+  const v1PoolDeployedLogs = await getLogs2({ api, target: V1_FACTORY, fromBlock: v1StartBlock, eventAbi: abi.PoolDeployed, })
+  const v1point1PoolDeployedLogs = await getLogs2({ api, target: V1_POINT_1_FACTORY, fromBlock: v1point1StartBlock, eventAbi: abi.PoolDeployed, })
   const uniPools = poolDeployedLogs.map(log => log.uniswapPool.toLowerCase())
   const token0s = await api.multiCall({ abi: 'address:token0', calls: uniPools })
   const token1s = await api.multiCall({ abi: 'address:token1', calls: uniPools })
@@ -47,7 +51,7 @@ async function tvl(api) {
   const poolData = {}
   const ownerTokens = []
   uniPools.forEach((pool, i) => {
-    // to compte tokens locked in panoptic pools
+    // to compute tokens locked in panoptic pools
     ownerTokens.push([[token0s[i], token1s[i]], poolDeployedLogs[i].poolAddress])
 
     // to compute value locked in uni v3 pools
@@ -64,6 +68,8 @@ async function tvl(api) {
   chunks.forEach(chunk => {
     const { token0, token1, tick, } = poolData[chunk.pool.id.toLowerCase()] ?? {}
     if (!tick) return;
+    // The chunk may be from Uni v3 or v4, but it seems that so long as we can pass in the required args,
+    // that distinction doesn't matter:
     addUniV3LikePosition({ api, token0, token1, tick, liquidity: chunk.netLiquidity, tickUpper: chunk.tickUpper, tickLower: chunk.tickLower, })
   })
 }

--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -37,7 +37,7 @@ const config = {
 }
 
 
-async function tvlV1(api) {
+async function tvl(api) {
   const chain = api.chain
   const { v1StartBlock, graphUrl, safeBlockLimit } = config[chain]
 


### PR DESCRIPTION
Got the SFPM and Factory addresses from: https://github.com/panoptic-labs/panoptic-subgraph/blob/v4-support/config/mainnet.json

Got the start block from this deploy tx: https://etherscan.io/tx/0x54cd540d3ba3f7b069e39192cc374730e4fc10326cd995f6be84f5ce1ed01013

[The chunks and pool objects on the subgraph seem to still support all the same fields we need](https://github.com/panoptic-labs/panoptic-subgraph/compare/dev...v4-support)

The [PoolDeployed event](https://github.com/panoptic-labs/panoptic-v1-core/compare/v1.1.x...v1.0.x#diff-f990143423ecab9a65b66223a35cf2914d47090c9f32e73c74a6761737ca370eL40) changed slightly, but only dropped two fields we didn't need (and weren't even in the ABI this adapter uses anyways). The `PoolInitialized` event is unchanged (and also unused in the adapter, it seems - maybe we could delete that line?).

A bit unrelated: I also made it so that we use the /prod alias in subgraph URL, so that this adapter is always tracking the most recent subgraph logic.

TODO: Call PoolManager to get token0/token1/slot0 for the univ4 pools: https://docs.uniswap.org/contracts/v4/guides/read-pool-state